### PR TITLE
Fix misused `MSVC_DEBUG_INFORMATION_FORMAT`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ if(ENABLE_RELEASE_LTO)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL ON) # Enable LTO
 endif()
 
-set(MSVC_DEBUG_INFORMATION_FORMAT Embedded)
+set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)
 
 # Add the modules to the project
 add_subdirectory(extern)


### PR DESCRIPTION
`MSVC_DEBUG_INFORMATION_FORMAT` is a target property, not a variable, so setting it as a variable won't have any effect. To set debug information format global variable `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` should be used.

https://cmake.org/cmake/help/latest/prop_tgt/MSVC_DEBUG_INFORMATION_FORMAT.html#
https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_DEBUG_INFORMATION_FORMAT.html